### PR TITLE
Add travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .config
 .yardoc
 Gemfile.lock
+node_modules
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+---
+language: ruby
+script: bundle exec rspec spec
+rvm:
+  - 1.9.3
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@
 language: ruby
 script: bundle exec rspec spec
 rvm:
-  - 1.9.3
+  - 2.0.0
 sudo: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pincers ![Build Status][travis-badge]
 
-[travis-badge]: https://travis-ci.org/nicolasmery/pincers.svg?branch=master
+[travis-badge]: https://travis-ci.org/platanus/pincers.svg?branch=master
 
 Pincers is a jQuery inspired web automation framework with multiple backend support.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Pincers
+# Pincers ![Build Status][travis-badge]
+
+[travis-badge]: https://travis-ci.org/nicolasmery/pincers.svg?branch=master
 
 Pincers is a jQuery inspired web automation framework with multiple backend support.
 


### PR DESCRIPTION
Once this is merged is still required to go to travis-ci.org and setup the repository in order to travis to work.

