### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ parents = pincers.search('.my-class')
 parents.search('.child-class') # will select all childs except fourth-child
 ```
 
-If you don't feel confortable using **css**, pincers also provides a more idiomatic `search` method, it allows you to search by `tag`, `contents`, `class` or any attribute:
+If you don't feel comfortable using **css**, pincers also provides a more idiomatic `search` method, it allows you to search by `tag`, `contents`, `class` or any attribute:
 
 ```ruby
 pincers.search(tag: 'p', class: 'some-class other-class')


### PR DESCRIPTION
@platanus, I've corrected a typographical error in the documentation of the [pincers](https://github.com/platanus/pincers) project. Specifically, I've changed confortable to comfortable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.